### PR TITLE
Add PHPStan Level 5 static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "fix": [
             "phpcbf --standard=phpcs.ruleset.xml includes",
             "phpcbf --standard=phpcs.ruleset.xml hide-author-archive.php"
-        ]
+        ],
+        "phpstan": "phpstan analyse --memory-limit=1G"
     },
     "repositories": [
         {
@@ -43,7 +44,10 @@
         "squizlabs/php_codesniffer": "^3.0.0",
         "wp-coding-standards/wpcs": "^3.0.0",
         "yoast/phpunit-polyfills": "^2.0",
-        "wpackagist-plugin/wordpress-seo": "^24.3"
+        "wpackagist-plugin/wordpress-seo": "^24.3",
+        "phpstan/phpstan": "^2.1",
+        "szepeviktor/phpstan-wordpress": "^2.0",
+        "php-stubs/wordpress-stubs": "^6.9"
     },
     "config": {
         "allow-plugins": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Found usage of constant DOING_AJAX\. Use wp_doing_ajax\(\) instead\.$#'
+			identifier: phpstanWP.wpConstant.fetch
+			count: 1
+			path: includes/functions-admin.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - hide-author-archive.php
+        - includes/


### PR DESCRIPTION
## Summary
- PHPStan Level 5 + WordPress extensions を追加
- 既存エラーは baseline に記録（新規コードのみ Level 5 準拠を要求）
- `composer phpstan` で実行可能

タロスカイ全プラグイン標準化の一環。

🤖 Generated with [Claude Code](https://claude.com/claude-code)