### PR TITLE
Add phpstan files to .distignore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -23,6 +23,8 @@ phpunit.xml.dist
 multisite.xml
 multisite.xml.dist
 phpcs.ruleset.xml
+phpstan.neon
+phpstan-baseline.neon
 README.md
 wp-cli.local.yml
 tests


### PR DESCRIPTION
## Summary
- Add phpstan.neon and phpstan-baseline.neon to .distignore to exclude from WordPress.org deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)