### PR TITLE
Replace bin/build.sh with direct composer install in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Install Composer Dependencies
         run: composer install --no-dev --prefer-dist
 
-      - name: Build Assets
-        run: bash bin/build.sh ${{ github.event.release.tag_name }}
-
       - name: Generate readme.txt
         uses: tarosky/workflows/actions/wp-readme@main
 


### PR DESCRIPTION
## Summary
- Replace `bash bin/build.sh` with direct `composer install --no-dev`
- No Node.JS/npm needed (plugin has no JS/CSS assets)

## Test plan
- [ ] Verify deploy workflow runs correctly on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)