### PR TITLE
Add build_command to Playground preview workflow

### DIFF
--- a/.github/workflows/playground-preview-build.yml
+++ b/.github/workflows/playground-preview-build.yml
@@ -13,3 +13,5 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'playground') &&
       (github.event.action != 'labeled' || github.event.label.name == 'playground')
     uses: tarosky/workflows/.github/workflows/playground-preview-build.yml@main
+    with:
+      build_command: 'composer install --no-dev --prefer-dist'


### PR DESCRIPTION
## Summary
- Add explicit `build_command` to Playground preview build workflow
- Sets `composer install --no-dev --prefer-dist` since this plugin has no JS/CSS build step
- PRs labeled with `playground` will get a WordPress Playground preview link as a comment

## Test plan
- [ ] Create a test PR, add `playground` label, verify preview link appears